### PR TITLE
refactor(server): :recycle: accept both connection string or separated values from env file

### DIFF
--- a/marvelog-server/.env.example
+++ b/marvelog-server/.env.example
@@ -13,17 +13,20 @@ DB_NAME=
 # Connection to the database
 DB_HOST=
 
-# Database port
-DB_PORT=
-
-# Outside port for the database
-OTS_PORT=
-
 # The user of database
 DB_USER=
 
 # The pass of the database
 DB_PASS=
+
+# Database connection string
+DATABASE_URL=
+
+# Database port
+DB_PORT=
+
+# Outside port for the database
+OTS_PORT=
 
 # The port you want you application runs on
 PORT=

--- a/marvelog-server/src/config/db/db.module.ts
+++ b/marvelog-server/src/config/db/db.module.ts
@@ -33,7 +33,14 @@ const modelProviders = models.map((model) => ({
       useFactory: async (config: EnvService) => {
         const knex = Knex({
           client: 'mysql2',
-          connection: config.dbConStr,
+          connection: config.dbConStr || {
+            host: config.dbHost,
+            database: config.dbName,
+            port: config.dbPort,
+            user: config.dbUser,
+            password: config.dbPass,
+            connectTimeout: 60000,
+          },
           debug: config.env !== 'prod',
           pool: { min: 2, max: 10 },
         });

--- a/marvelog-server/src/config/env/appConfig.ts
+++ b/marvelog-server/src/config/env/appConfig.ts
@@ -2,7 +2,7 @@ import { registerAs } from '@nestjs/config';
 
 export default registerAs('app', () => ({
   port: process.env.PORT,
-  dbConStr: process.env.DB_CON_STR,
+  dbConStr: process.env.DATABASE_URL,
   dbName: process.env.DB_NAME,
   dbHost: process.env.DB_HOST,
   dbPort: process.env.DB_PORT,


### PR DESCRIPTION
Database connection now can be done informing a connection string or separated values in env file. Connection string takes priority, in case both options are present.